### PR TITLE
Added ES5 compliant reduce and unit tests

### DIFF
--- a/lib/shims/array.js
+++ b/lib/shims/array.js
@@ -72,6 +72,7 @@
 		'array-map': 'map',
 		'array-filter': 'filter',
 		'array-reduce': 'reduce',
+		'array-reduceright': 'reduceRight',
 		'array-indexof': 'indexOf',
 		'array-lastindexof': 'lastIndexOf'
 	};
@@ -101,15 +102,15 @@
 
 			var alo = Object(arr),
 				len = alo.length >>> 0,
-				i;
+				i = 0;
 
 			if (arr == undef || !isFunction(lambda)) {
 				throw new TypeError();
 			}
 
-			for (i = 0; i < len; i++) {
+			for (; i < len; ++i) {
 				if (i in alo) {
-					if (!lambda.call(context, i, alo[i], alo)) {
+					if (lambda.call(context, alo[i], i, alo) === false) {
 						return false;
 					}
 				}
@@ -121,12 +122,8 @@
 
 	if (!has('array-foreach')) {
 		missing.forEach = function (lambda, context) {
-			iterate(this, function (item, i, arr) { lambda(item, i, arr); return true; }, context);
+			iterate(this, lambda, context);
 		};
-		each = iterate;
-	}
-	else {
-		each = function (arr, lambda, context) { proto.forEach.call(arr, lambda, context); };
 	}
 
 	if (!has('array-every')) {
@@ -137,7 +134,7 @@
 
 	if (!has('array-some')) {
 		missing.some = function (lambda, context) {
-			return iterate(this, function (item, i, arr) { return !lambda(item, i, arr); }, context);
+			return iterate(this, function (item, i, arr) { return !lambda.call(this, item, i, arr); }, context);
 		};
 	}
 
@@ -181,6 +178,8 @@
 	}
 	
 	if (!has('array-reduce')) {
+        // ES5 reduce
+        // http://es5.github.com/#x15.4.4.21
 		missing.reduce = function(reduceFunc /*, initialValue */) {
             // ES5 dictates that reduce.length === 1
 
@@ -226,6 +225,59 @@
             return reduced;
         };
 	}
+
+    if (!has('array-reduceright')) {
+        // ES5 reduceRight
+        // http://es5.github.com/#x15.4.4.22
+        missing.reduceRight = function (reduceFunc /*, initialValue */) {
+            // ES5 dictates that reduceRight.length === 1
+
+            // NOTE: reduceRight operates from right to left, so references below
+            // to the "first" item mean the right-most item, second item means
+            // second-to-right-most, etc.
+
+            var arr, args, reduced, len, i;
+
+            arr = Object(this);
+
+            if (arr === undef || !isFunction(reduceFunc)) {
+                throw new TypeError();
+            }
+
+            len = arr.length >>> 0;
+            i = len - 1;
+            args = arguments;
+
+            // If no initialValue, use first item of array (we know length !== 0 here)
+            // and adjust i to start at second item
+            if (args.length <= 1) {
+                // Skip to the first real element in the array
+                for (;;) {
+                    if (i in arr) {
+                        reduced = arr[i--];
+                        break;
+                    }
+
+                    // If we reached the beginning of the array without finding any real
+                    // elements, it's a TypeError
+                    if (--i < 0) {
+                        throw new TypeError();
+                    }
+                }
+            } else {
+                // If initialValue provided, use it
+                reduced = args[1];
+            }
+
+            // Do the actual reduce
+            for (; i >= 0; --i) {
+                // Skip holes
+                if (i in arr) reduced = reduceFunc(reduced, arr[i], i, arr);
+            }
+
+            return reduced;
+        };
+    }
 
 	/***** finders *****/
 
@@ -283,9 +335,9 @@
 	// augment prototype if requested
 	var polyfill;
 	polyfill = function () {
-		each(missing, function (method) {
-			proto[method] = exports[method];
-		});
+        for(var method in missing) {
+			proto[method] = missing[method];
+        }
 		if (!Array.isArray) {
 			Array.isArray = isArray;
 		}
@@ -296,6 +348,15 @@
 		// don't ever run polyfill again even if it is called again
 		polyfill = function () {};
 	};
+
+    // FIXME: methods are not exported? i.e. exportMethod is never called?
+    // It seems odd to only export methods that are missing from Array.prototype
+    // when this shim is used as a module rather than a polyfill.  Seems like
+    // all methods should be exported so that the API is consistent.
+    //
+    // Maybe the pattern should be:
+    // missing.featureMethod = function(...) {...}
+    // if(!has(feature)) { exports.featureMethod = missing.featureMethod; }
 
 	define(exports);
 

--- a/test/array.html
+++ b/test/array.html
@@ -19,6 +19,16 @@
 
 <script>
 
+// For testing in an ES env, remove shimmed methods first
+//    Array.prototype.forEach = null;
+//    Array.prototype.map = null;
+//    Array.prototype.every = null;
+//    Array.prototype.some = null;
+//    Array.prototype.indexOf = null;
+//    Array.prototype.lastIndexOf = null;
+//    Array.prototype.reduce = null;
+//    Array.prototype.reduceRight = null;
+
 	curl(['poly!array']).then(
 		function () {
 			runTests();
@@ -57,11 +67,18 @@
 
 		// test forEach
 		assertTrue('forEach hits all items', function () {
-			var sum = 0;
+			var expected, sum;
+            expected = 0;
+            sum = 0;
 			testArray.forEach(function (item, i) {
-				sum |= Math.pow(2, i);
+				sum += i;
 			});
-			return sum == 0xff;
+
+            for(var i=0; i<testArray.length; i++) {
+                expected += i;
+            }
+            
+			return expected === sum;
 		});
 		assertTrue('forEach applies context correctly', function () {
 			var context = { sum: 0 };
@@ -105,11 +122,18 @@
 		function sum(a, b) {
 			return a + b;
 		}
+        
+        function sub(a, b) {
+            return a - b;
+        }
 		
 		// tests
 		assertEquals('reduce handles valid input', function() {
 			return [1,1,1].reduce(sum);
 		}, 3);
+        assertEquals('reduce is left to right', function() {
+            return [3,2,1].reduce(sub);
+        }, 0);
 		assertEquals('reduce handles valid input with initial value', function() {
 			return [1,1,1].reduce(sum, 1);
 		}, 4);
@@ -127,6 +151,31 @@
 				return e instanceof TypeError;
 			}
 		});
+
+        // tests
+        assertEquals('reduceRight handles valid input', function() {
+            return [1,1,1].reduceRight(sum);
+        }, 3);
+        assertEquals('reduceRight is right to left', function() {
+            return [1,2,3].reduceRight(sub);
+        }, 0);
+        assertEquals('reduceRight handles valid input with initial value', function() {
+            return [1,1,1].reduceRight(sum, 1);
+        }, 4);
+        assertEquals('reduceRight handles sparse arrays', function() {
+            return [,1,,1,1].reduceRight(sum);
+        }, 3);
+        assertEquals('reduceRight returns initial value for empty array', function() {
+            return [].reduceRight(sum, 1);
+        }, 1);
+        assertTrue('reduceRight throws TypeError for empty array and no initial value', function() {
+            try {
+                [].reduceRight(sum);
+                return false;
+            } catch(e) {
+                return e instanceof TypeError;
+            }
+        });
 
 		// indexOf and lastIndexOf tests
 		assertEquals('indexOf finds item in first position', function () {


### PR DESCRIPTION
I didn't use the iterate() function, since getting all the ES5 required checks in there makes it a little more complicated.  Feel free to refactor it to use iterate(), tho!
