### PR TITLE
Object.getPrototypeOf should return null when the parameter is Object.prototype

### DIFF
--- a/object.js
+++ b/object.js
@@ -87,6 +87,11 @@ define(['./lib/_base'], function (base) {
 		? function (object) { assertIsObject(object); return object.__proto__; }
 		: function (object) {
 			assertIsObject(object);
+			// return null according to the investigation result at: 
+			// https://github.com/cujojs/poly/pull/21
+			if (object == refProto) {
+				return null;
+			}
 			return protoSecretProp && object[protoSecretProp](secrets)
 				? object[protoSecretProp](secrets.proto)
 				: object.constructor ? object.constructor.prototype : refProto;

--- a/test/object.html
+++ b/test/object.html
@@ -183,6 +183,12 @@ curl(['test/testutils', 'poly/object', 'domReady!'], function (tester) {
 			return Object.getPrototypeOf(child) == proto;
 		});
 
+		// According to the investigation result at:
+		// https://github.com/cujojs/poly/pull/21/files
+		tester.assertTrue('Object.getPrototypeOf should return null when the parameter is Object.prototype', function(){
+			return Object.getPrototypeOf(Object.prototype) === null;
+		});
+
 		// test keys
 		tester.assertTrue('Object.keys should loop through all keys and nothing but the keys', function () {
 			var test, ref, keys, result, key;


### PR DESCRIPTION
this is a following up pull request for #21
