### PR TITLE
Fix npm warning: 'repositories' (plural) Not supported. Please pick one ...

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,10 @@
             "url": "http://www.opensource.org/licenses/mit-license.php"
         }
     ],
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/cujojs/poly"
-        }
-    ],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/cujojs/poly"
+    },
     "bugs": "https://github.com/cujojs/poly/issues",
     "maintainers": [
         {


### PR DESCRIPTION
...as the 'repository' field