### PR TITLE
Update hasProp to handle object not derived from Object

### DIFF
--- a/object.js
+++ b/object.js
@@ -259,7 +259,7 @@ define(function (require) {
 
 	// for better compression
 	function hasProp (object, name) {
-		return object.hasOwnProperty(name);
+		return Object.hasOwnProperty.call(object, name);
 	}
 
 	function _keys (object) {

--- a/object.js
+++ b/object.js
@@ -259,7 +259,7 @@ define(function (require) {
 
 	// for better compression
 	function hasProp (object, name) {
-		return Object.hasOwnProperty.call(object, name);
+		return refProto.hasOwnProperty.call(object, name);
 	}
 
 	function _keys (object) {


### PR DESCRIPTION
This is change was needed in our project since we had custom objects that inherits null and not **Object**. In this case it fails in IE8 since the **hasProp** method assumes the first param **object** to inherit **Object** which is not the case always. 
